### PR TITLE
print query vector before reshape

### DIFF
--- a/examples/text_example.py
+++ b/examples/text_example.py
@@ -51,8 +51,14 @@ expanded_metadata = metadata_list * 10
 for replica in hug_db_replicas:
     replica.build_index((vectors * 10)[:-1], metadata_list)
 
-query_vector = vectors[-1][1]
+query_vector = vectors[-1]
 metada_filter = lambda metadata: metadata["category"] == "A" and metadata["length"] == "short"
+
+print("Query vector before re-shape:", query_vector)
+query_vector = query_vector.reshape(1, -1)
+print("Query vector shape after reshape:", query_vector.shape)
+
+print("Indexed vectors dimension:", hug_db_replicas[0].index.d)
 distances, results = hug_db_replicas[0].search(query_vector.reshape(1, -1), k=2, metadata_filter=metada_filter)
 
 print("Search results:", results)


### PR DESCRIPTION
prints vector shape before and after reshape to test instability. The issue was caused by the number of training points provided. see [Issue](https://github.com/alexndrvega/HugVector/issues/8)